### PR TITLE
Fix crash issue when using webcam

### DIFF
--- a/monoloco/visuals/webcam.py
+++ b/monoloco/visuals/webcam.py
@@ -66,7 +66,7 @@ def webcam(args):
             outputs, varss = monoloco.forward(keypoints, kk)
             dic_out = monoloco.post_process(outputs, varss, boxes, keypoints, kk, dict_gt)
             visualizer_monoloco.send((pil_image, dic_out))
-            end = time.time()
+        end = time.time()
         print("run-time: {:.2f} ms".format((end-start)*1000))
 
     cam.release()


### PR DESCRIPTION
Reproduce way: When there is no pedestrian exist at first. (Ex. Use something to hide the camera, so the input image will just a black screen)

In this case, the `if pifpaf_out` condition will not execute, and the variable `end` will not be defined.
The program will crash at `print` line.
```python
if pifpaf_out:
    boxes, keypoints = preprocess_pifpaf(pifpaf_out, (width, height))
    outputs, varss = monoloco.forward(keypoints, kk)
    dic_out = monoloco.post_process(outputs, varss, boxes, keypoints, kk, dict_gt)
    visualizer_monoloco.send((pil_image, dic_out))
    end = time.time()
print("run-time: {:.2f} ms".format((end-start)*1000)) # The program will crash here
```